### PR TITLE
Admin notice for import does not work issue

### DIFF
--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -23,8 +23,8 @@ class CfsRequireImport {
 
 		$result = CFS()->field_group->import( $options );
 
-		// FIXME
-		add_action( 'admin_notices', function() {
+		// FIXED
+		add_action( 'admin_notices', function() use ($result){
 			echo '<div class="updated"><p>' . strip_tags( $result ) . '</p></div>';
 		} );
 	}


### PR DESCRIPTION
In the "add_action( 'admin_notices..." must be "function() use ($result)" to use the $result variable in the anonymous function.