### PR TITLE
Admin notice for import does not work FIX and additional edits.

### DIFF
--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -12,14 +12,12 @@ include_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
 class CfsRequireImport {
 	
-	private $result = 'blank';
-
 	function __construct() {
 		register_activation_hook( plugin_basename( __FILE__ ), array( $this, 'import_cfs_fields' ) );
 		add_action('admin_notices', array( $this, 'print_import_notice'));
 	}
 
-	public function import_cfs_fields() {
+	public static function import_cfs_fields() {
 		$fields = file_get_contents( trailingslashit( dirname( __FILE__ ) ) . 'fields.json' );
 
 		$options = array(
@@ -31,7 +29,7 @@ class CfsRequireImport {
 		set_transient('cfs_import_result', $this->result, 60);
 	}
 	
-	public function print_import_notice() {
+	public static function print_import_notice() {
 		 if ( get_transient( 'cfs_import_result' ) ) {
 			 echo '<div class="updated"><p>' . get_transient( 'cfs_import_result' ) . '</p></div>';
 			 delete_transient( 'cfs_import_result' );

--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -8,32 +8,41 @@ Author: Chris Van Patten / Van Patten Media Inc.
 Author URI: https://www.vanpattenmedia.com/
 */
 
+include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+
 class CfsRequireImport {
+	
+	private $result = 'blank';
 
 	function __construct() {
 		register_activation_hook( plugin_basename( __FILE__ ), array( $this, 'import_cfs_fields' ) );
+		add_action('admin_notices', array( $this, 'print_import_notice'));
 	}
 
-	public static function import_cfs_fields() {
+	public function import_cfs_fields() {
 		$fields = file_get_contents( trailingslashit( dirname( __FILE__ ) ) . 'fields.json' );
 
 		$options = array(
-			'import_code' => json_decode( stripslashes( $fields ), true ),
+			'import_code' => json_decode( $fields , true ),
 		);
 
-		$result = CFS()->field_group->import( $options );
-
-		// FIXME
-		add_action( 'admin_notices', function() {
-			echo '<div class="updated"><p>' . strip_tags( $result ) . '</p></div>';
-		} );
+		$this->result = CFS()->field_group->import( $options );
+		
+		set_transient('cfs_import_result', $this->result, 60);
+	}
+	
+	public function print_import_notice() {
+		 if ( get_transient( 'cfs_import_result' ) ) {
+			 echo '<div class="updated"><p>' . get_transient( 'cfs_import_result' ) . '</p></div>';
+			 delete_transient( 'cfs_import_result' );
+		 }
 	}
 }
 
 
-if ( class_exists( 'Custom_Field_Suite' ) ) {
+if ( is_plugin_active('custom-field-suite/cfs.php') ) {
 
-	new CfsPluginDemo;
+	new CfsRequireImport();
 
 } else {
 

--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -24,9 +24,9 @@ class CfsRequireImport {
 			'import_code' => json_decode( $fields , true ),
 		);
 
-		$this->result = CFS()->field_group->import( $options );
+		$result = CFS()->field_group->import( $options );
 		
-		set_transient('cfs_import_result', $this->result, 60);
+		set_transient('cfs_import_result', $result, 60);
 	}
 	
 	public static function print_import_notice() {

--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -8,48 +8,46 @@ Author: Chris Van Patten / Van Patten Media Inc.
 Author URI: https://www.vanpattenmedia.com/
 */
 
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-
 class CfsRequireImport {
 	
 	function __construct() {
 		
-		/* Register activation hook. */
-		register_activation_hook( plugin_basename( __FILE__ ), array( $this , 'import_cfs_fields' ) );
+		// Register activation hook.
+		register_activation_hook( plugin_basename( __FILE__ ), array( $this, 'import_cfs_fields' ) );
 		
-		/* Add admin notice */
-		add_action( 'admin_notices' , array( $this , 'print_import_notice' ) );
+		// Add admin notice
+		add_action( 'admin_notices' , array( $this, 'print_import_notice' ) );
 	}
 	
- 	/* Runs only when the plugin is activated. */
+ 	// Runs only when the plugin is activated.
 	public static function import_cfs_fields() {
 		$fields = file_get_contents( trailingslashit( dirname( __FILE__ ) ) . 'fields.json' );
 
 		$options = array(
-			'import_code' => json_decode( $fields , true ),
+			'import_code' => json_decode( $fields, true ),
 		);
 
 		$result = CFS()->field_group->import( $options );
 		
-		/* Create transient data */
-		set_transient( 'cfs_import_result' , $result , 60 );
+		// Create transient data
+		set_transient( 'cfs_import_result', $result, 60 );
 	}
 	
-	/* Admin Notice on Activation. */
+	// Admin Notice on Activation.
 	public static function print_import_notice() {
 		
-		/* Check transient, if available display notice */
+		// Check transient, if available display notice
 		if ( get_transient( 'cfs_import_result' ) ) {
 			echo '<div class="updated"><p>' . get_transient( 'cfs_import_result' ) . '</p></div>';
 			
-			/* Delete transient, only display this notice once. */
+			// Delete transient, only display this notice once.
 			delete_transient( 'cfs_import_result' );
 		}
 	}
 }
 
 
-if ( is_plugin_active( 'custom-field-suite/cfs.php' ) ) {
+if ( is_admin() && in_array( 'custom-field-suite/cfs.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 
 	new CfsRequireImport();
 

--- a/cfs-require-import.php
+++ b/cfs-require-import.php
@@ -8,15 +8,20 @@ Author: Chris Van Patten / Van Patten Media Inc.
 Author URI: https://www.vanpattenmedia.com/
 */
 
-include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 class CfsRequireImport {
 	
 	function __construct() {
-		register_activation_hook( plugin_basename( __FILE__ ), array( $this, 'import_cfs_fields' ) );
-		add_action('admin_notices', array( $this, 'print_import_notice'));
+		
+		/* Register activation hook. */
+		register_activation_hook( plugin_basename( __FILE__ ), array( $this , 'import_cfs_fields' ) );
+		
+		/* Add admin notice */
+		add_action( 'admin_notices' , array( $this , 'print_import_notice' ) );
 	}
-
+	
+ 	/* Runs only when the plugin is activated. */
 	public static function import_cfs_fields() {
 		$fields = file_get_contents( trailingslashit( dirname( __FILE__ ) ) . 'fields.json' );
 
@@ -26,19 +31,25 @@ class CfsRequireImport {
 
 		$result = CFS()->field_group->import( $options );
 		
-		set_transient('cfs_import_result', $result, 60);
+		/* Create transient data */
+		set_transient( 'cfs_import_result' , $result , 60 );
 	}
 	
+	/* Admin Notice on Activation. */
 	public static function print_import_notice() {
-		 if ( get_transient( 'cfs_import_result' ) ) {
-			 echo '<div class="updated"><p>' . get_transient( 'cfs_import_result' ) . '</p></div>';
-			 delete_transient( 'cfs_import_result' );
-		 }
+		
+		/* Check transient, if available display notice */
+		if ( get_transient( 'cfs_import_result' ) ) {
+			echo '<div class="updated"><p>' . get_transient( 'cfs_import_result' ) . '</p></div>';
+			
+			/* Delete transient, only display this notice once. */
+			delete_transient( 'cfs_import_result' );
+		}
 	}
 }
 
 
-if ( is_plugin_active('custom-field-suite/cfs.php') ) {
+if ( is_plugin_active( 'custom-field-suite/cfs.php' ) ) {
 
 	new CfsRequireImport();
 


### PR DESCRIPTION
1. Admin notice Issue Fixed with WP Transient API. 
2. class_exists refused to work and was replaced with ~~is_plugin_active. It needed include_once(ABSPATH . 'wp-admin/includes/plugin.php');~~ is_admin() && in_array( 'custom-field-suite/cfs.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ). It does not need any include. 
3. new CfsPluginDemo; replaced with new CfsRequireImport(); for normal functioning.
4. ~~Used non-static functions and field.~~
5. Removed stripslashes in json_decode because with it function denied to decode json file.
6. Tested on Clean WordPress 4.8.2 with plugin Custom Field Suite Version 2.5.10, TGM Plugin Activation 2.6.1, PHP Version 5.5.38 with sample fields.json and it works as it should!
7. Added some comments for admin notice code.